### PR TITLE
Rancher projects improved

### DIFF
--- a/manifests/grafana-dashboard-projects.json
+++ b/manifests/grafana-dashboard-projects.json
@@ -37,7 +37,20 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*(Storage|Memory).*/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 7,
@@ -96,7 +109,20 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*(Storage|Memory).*/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -333,5 +359,5 @@
   "timezone": "",
   "title": "Rancher Project",
   "uid": "D-WQ6dYVk",
-  "version": 10
+  "version": 11
 }

--- a/query/rancher/rancherBase.go
+++ b/query/rancher/rancherBase.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"net/http"
+	"net"
 )
 
 var (
@@ -98,6 +99,12 @@ func (r Client) GetK8sDistributions() (map[string]int, error) {
 }
 
 func (r Client) GetLatestRancherVersion() (string, error) {
+
+	// check dns resultion first, if this fails http.Get segfaults
+	_, err := net.LookupHost("api.github.com")
+	if err != nil {
+	  return "no internet", nil
+        }
 	resp, err := http.Get("https://api.github.com/repos/rancher/rancher/releases/latest")
 
 	defer resp.Body.Close()

--- a/query/rancher/rancherProjects.go
+++ b/query/rancher/rancherProjects.go
@@ -5,8 +5,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"regexp"
-	"strconv"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var (
@@ -147,15 +146,13 @@ func (r Client) GetProjectResourceQuota() ([]projectResource, error) {
 		if projectClusterName != "" {
 
 			for key, value := range projectResourceQuotas {
-
-				//Strip any non-numeric values from string
-				re := regexp.MustCompile("[0-9]+")
-				strippedString := re.FindAllString(value.(string), -1)
-
-				convertedValue, err := strconv.ParseFloat(strippedString[0], 64)
+                                 var convertedValue float64
+				// Convert the Quota values to base numeric value, defined by unit
+				quantity, err := resource.ParseQuantity(value.(string))
 				if err != nil {
-					return nil, err
+					continue
 				}
+                                convertedValue = float64(quantity.Value())
 
 				resource := projectResource{
 					Projectid:          projectValue.GetName(),
@@ -177,15 +174,13 @@ func (r Client) GetProjectResourceQuota() ([]projectResource, error) {
 			}
 
 			for key, value := range projectResourceQuotas {
-
-				//Strip any non-numeric values from string
-				re := regexp.MustCompile("[0-9]+")
-				strippedString := re.FindAllString(value.(string), -1)
-
-				convertedValue, err := strconv.ParseFloat(strippedString[0], 64)
+                                 var convertedValue float64
+                                // Convert the Quota values to base numeric value, defined by unit
+                                quantity, err := resource.ParseQuantity(value.(string))
 				if err != nil {
-					return nil, err
+				    continue
 				}
+			       	convertedValue = float64(quantity.Value())
 				resource := projectResource{
 					Projectid:          projectValue.GetName(),
 					ProjectDisplayName: projectDisplayName,


### PR DESCRIPTION
This improves the implementation for Issue "Add metrics on rancher project and related namespaces (Issue #12)" in the following two aspects:

### quota Unit clash

The units returned for the same resources can differ in Rancher.
Especially hard and used value are using different units in my test project:

Instead of just stripping the unit part, it should first be converted to the standard units e.g. like is a the func ExampleMustParse from 

https://github.com/kubernetes/apimachinery/blob/adc6f4cd9e7d28fc1c1e5efc658d940d55c0f356/pkg/api/resource/quantity_example_test.go


### air gapped setup not working

The container is crashlooping, when it has no internet connection and the DNS lookup return to github.com returns "BAD ADDRESS"
When I add a proxy it works fine.

```
time="2023-04-07T08:12:23Z" level=info msg="Building Rancher Client"
time="2023-04-07T08:12:23Z" level=info msg="Beginning to serve on port :8080"
time="2023-04-07T08:12:26Z" level=info msg="updating rancher metrics" source="collector.go:201"
time="2023-04-07T08:12:38Z" level=info msg="updating rancher metrics" source="collector.go:201"
time="2023-04-07T08:12:51Z" level=info msg="updating rancher metrics" source="collector.go:201"
time="2023-04-07T08:13:04Z" level=info msg="updating rancher metrics" source="collector.go:201"
time="2023-04-07T08:13:17Z" level=info msg="updating rancher metrics" source="collector.go:201"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x9834e5]

goroutine 54 [running]:
github.com/david-vtuk/prometheus-rancher-exporter/query/rancher.Client.GetLatestRancherVersion({{0xc00029c0f0?, 0xc0002ac780?}, 0xc000076f88?})
        /prometheus-rancher-exporter/query/rancher/rancher.go:103 +0x65
github.com/david-vtuk/prometheus-rancher-exporter/collector.Collect.func1()
        /prometheus-rancher-exporter/collector/collector.go:188 +0xf0
created by github.com/david-vtuk/prometheus-rancher-exporter/collector.Collect
        /prometheus-rancher-exporter/collector/collector.go:181 +0x16d
```